### PR TITLE
resultでの500エラーを修正

### DIFF
--- a/Repository/QuestionDAO.py
+++ b/Repository/QuestionDAO.py
@@ -69,6 +69,19 @@ class QuestionDAO:
                 question_dict.append(dict(row))
 
         return question_dict
+    
+    def get_question_all(self):
+        con = settings().connect()
+        sql = f"SELECT * FROM question_list"
+
+        with con.cursor(cursor_factory=DictCursor) as cur:
+            cur.execute(sql)
+            results = cur.fetchall()
+            question_dict = []
+            for row in results:
+                question_dict.append(dict(row))
+
+        return question_dict
 
     """
     引数の　game_idから、answer_tableの内容を検索してソートした後に、辞書型に変換して返す（find_questionを参考にどうぞ）

--- a/Service/QuestionService.py
+++ b/Service/QuestionService.py
@@ -16,10 +16,30 @@ class QuestionService:
         print("")
 
     """
+     - 回答が完了しているか　回答に誤りがないか
+     - 不正なgame_idでないか
+    を確認する
+    """
+    def __check_answer_list(self, game_id):
+        instance = QuestionDAO()
+        answered_dict = instance.find_answer(game_id)
+        all_answer_dict = instance.get_question_all()
+        if len(answered_dict) < len(all_answer_dict):
+            return "回答データが不足しています"
+        elif len(answered_dict) > len(all_answer_dict):
+            return "回答データが多いです"
+        else:
+            return "OK"
+
+    """
     DAOクラスの物を切り分け
     """
 
     def calc_point(self, game_id):
+        # 回答状況を確認(回答に不備があれば、例外を投げる)
+        res = self.__check_answer_list(game_id)
+        if res != "OK":
+            return res
         instance = QuestionDAO()
         numberOfCircleInstance = instance.get_number_of_circles()
         numberOfCircleList = numberOfCircleInstance.pop(0)

--- a/main.py
+++ b/main.py
@@ -83,7 +83,15 @@ def result():
 
     instance = QuestionService()
     result_circle_list = instance.calc_point(game_id)
-    return jsonify({'ranking': result_circle_list})
+    if type(result_circle_list) == list:
+        # 正常時
+        return jsonify({'ranking': result_circle_list})
+    elif type(result_circle_list) == str:
+        # 異常時
+        # 回答が完了していない
+        # 回答に誤りがある 
+        # 不正なgame_idである
+        return jsonify({"message": result_circle_list})
 
 
 @app.route('/end', methods=['GET', 'POST'])


### PR DESCRIPTION
QuestionService.py
```QuestionService.py
if len(answered_dict) < len(all_answer_dict):
    return "回答データが不足しています"
elif len(answered_dict) > len(all_answer_dict):
    return "回答データが多いです"
else:
     return "OK"
```

回答に不備がある状態で`/result`を叩いた時に500エラーではなく、エラーメッセージを返すようにする。

(例)
```
curl -X POST -H "Content-Type: application/json" -d '{"game_id":"314b8c3b-7dc3-479a-906d-8be9a8bcda4b"}' http://localhost:5000/result
{"message":"回答データが不足しています"}
```